### PR TITLE
when wasm contracts cross call, could not get the error code for the …

### DIFF
--- a/core/vm/wagon_runtime.go
+++ b/core/vm/wagon_runtime.go
@@ -1158,6 +1158,13 @@ func CallContract(proc *exec.Process, addrPtr, args, argsLen, val, valLen, callC
 	if err == nil || err == errExecutionReverted {
 		ctx.CallOut = ret
 	}
+
+	if nil != err {
+		if _, ok := err.(*common.BizError); ok {
+			ctx.CallOut = ret
+		}
+	}
+
 	ctx.contract.Gas += returnGas
 
 	return status
@@ -1217,6 +1224,13 @@ func DelegateCallContract(proc *exec.Process, addrPtr, params, paramsLen, callCo
 	if err == nil || err == errExecutionReverted {
 		ctx.CallOut = ret
 	}
+
+	if nil != err {
+		if _, ok := err.(*common.BizError); ok {
+			ctx.CallOut = ret
+		}
+	}
+
 	ctx.contract.Gas += returnGas
 
 	return status
@@ -1277,6 +1291,13 @@ func StaticCallContract(proc *exec.Process, addrPtr, params, paramsLen, callCost
 	if err == nil || err == errExecutionReverted {
 		ctx.CallOut = ret
 	}
+
+	if nil != err {
+		if _, ok := err.(*common.BizError); ok {
+			ctx.CallOut = ret
+		}
+	}
+
 	ctx.contract.Gas += returnGas
 
 	return status


### PR DESCRIPTION
when wasm contracts cross call, could not get the error code for the invoked contract